### PR TITLE
Added exit code in build script to prevent docker image from building

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -9,6 +9,9 @@ fi
 
 $buildpack/bin/detect /build /cache
 $buildpack/bin/compile /build /cache
-
+exit_code=$?
+if [ $exit_code != 0 ]; then 
+  exit $exit_code; 
+fi
 rm -rf /app
 cp -r /build /app


### PR DESCRIPTION
Currently, the docker image succeeds regardless of the whether the build succeeded or not. Adding the exit code check allows the build to fail.